### PR TITLE
fix: add pre-flight check to prevent trigger-key conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,30 @@ consul operator raft list-peers
 
 ## Troubleshooting
 
+### "Existing key does not match lock use" error
+
+If vip-elector fails to start with an error like:
+
+```
+trigger-key pre-flight check failed: existing key at 'network/sakura-internal/vip/lock' is a regular KV entry (Flags=0), not a lock key (expected Flags=3304740253564472344)
+```
+
+**Cause**: The trigger-key was manually created with `consul kv put` or by another tool, making it a regular KV entry instead of a lock key. Consul's Lock API requires a specific flag value to identify lock keys.
+
+**Resolution**:
+
+1. Delete the existing key:
+   ```bash
+   consul kv delete network/sakura-internal/vip/lock
+   ```
+
+2. Restart vip-elector - it will create the key correctly with lock flags
+
+**Prevention**:
+- **Do NOT pre-create the trigger-key** with `consul kv put`
+- Let vip-elector create and manage the trigger-key automatically
+- The trigger-key is an internal lock mechanism, not a configuration value
+
 ### Lock not acquired
 
 1. Check Consul connectivity:

--- a/main_test.go
+++ b/main_test.go
@@ -537,9 +537,11 @@ func TestVerifyLockKeyStateErrorDetails(t *testing.T) {
 // TestLockFlagValue verifies the magic constant matches Consul's implementation
 func TestLockFlagValue(t *testing.T) {
 	// This is the actual value from hashicorp/consul/api/lock.go
-	expectedValue := uint64(0x2ddccbc058a50c18)
+	// https://github.com/hashicorp/consul/blob/main/api/lock.go
+	const expectedValue uint64 = 0x2ddccbc058a50c18
 
 	if LockFlagValue != expectedValue {
-		t.Errorf("LockFlagValue mismatch: expected %d, got %d", expectedValue, LockFlagValue)
+		t.Errorf("LockFlagValue constant mismatch: expected 0x%x (%d), got 0x%x (%d)",
+			expectedValue, expectedValue, LockFlagValue, LockFlagValue)
 	}
 }


### PR DESCRIPTION
## Summary

- Add startup validation to detect trigger-key conflicts before lock acquisition
- Prevent "Existing key does not match lock use" errors when trigger-key is manually created as regular KV
- Add comprehensive unit tests with mock Consul client
- Document the error and resolution steps in README

## Problem

When trigger-key exists as a regular KV entry (created manually with `consul kv put` or by another tool), Consul's Lock API returns `ErrLockConflict: "Existing key does not match lock use"`. This causes all nodes to fail lock acquisition, resulting in no leader.

Root cause: Consul Lock API requires KV entries to have `Flags=0x2ddccbc058a50c18` (LockFlagValue), but regular KV entries have `Flags=0`.

## Solution

### 1. Pre-flight Check (main.go:100-103)
- Validates trigger-key state at startup
- Checks if existing key has correct lock flag
- Fails fast with clear error message and resolution steps

### 2. Error Message (main.go:247-254)
- Explains root cause (regular KV vs lock key, Flags mismatch)
- Provides specific resolution command (`consul kv delete ...`)
- Links to Consul Lock API implementation for reference

### 3. Unit Tests (main_test.go:486-611)
- Table-driven tests for 4 scenarios: no key, correct lock key, wrong flags
- Mock Consul client for testing without real Consul
- Validates error details and constant values

### 4. Documentation (README.md:257-280)
- Troubleshooting guide with error symptoms
- Prevention best practices
- Clear resolution steps

## Test Plan

- [x] Unit tests pass (9 test suites, 33 subtests)
- [x] Build succeeds
- [x] Pre-flight check detects regular KV entries
- [x] Error message includes resolution steps