### PR TITLE
feat: add version flag with commit hash and Go version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,6 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
 
 archives:
   - id: default

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,7 @@ builds:
       - -s -w
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 archives:
   - id: default

--- a/main.go
+++ b/main.go
@@ -7,12 +7,19 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/hashicorp/consul/api"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	// Build-time variables (set via -ldflags)
+	version = "0.1.2"
+	commit  = "unknown"
 )
 
 const (
@@ -123,6 +130,7 @@ func run() error {
 func parseFlags() (*Config, error) {
 	config := &Config{}
 
+	versionFlag := flag.Bool("version", false, "Show version information")
 	flag.StringVar(&config.VipManagerConfigPath, "vip-manager-config", "", "Path to vip-manager.yml (required)")
 	flag.StringVar(&config.CheckID, "check-id", "", "Consul service check ID to associate with session")
 	ttlStr := flag.String("ttl", defaultTTL, "Session TTL (e.g., 10s, 15s)")
@@ -132,6 +140,11 @@ func parseFlags() (*Config, error) {
 	flag.StringVar(&config.Hostname, "hostname", "", "Hostname to use for lock value (defaults to short hostname)")
 
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Printf("vip-elector version %s (commit: %s, go: %s)\n", version, commit, runtime.Version())
+		os.Exit(0)
+	}
 
 	if config.VipManagerConfigPath == "" {
 		return nil, fmt.Errorf("--vip-manager-config is required")

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	// Build-time variables (set via -ldflags)
 	version = "0.1.2"
 	commit  = "unknown"
+	date    = "unknown"
 )
 
 const (
@@ -142,7 +143,7 @@ func parseFlags() (*Config, error) {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Printf("vip-elector version %s (commit: %s, go: %s)\n", version, commit, runtime.Version())
+		fmt.Printf("vip-elector version %s (commit: %s, date: %s, go: %s)\n", version, commit, date, runtime.Version())
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Summary

- Add `-version` flag to display version information
- Version output includes version number (0.1.2), git commit hash, build date, and Go version
- Build-time variables are embedded via `-ldflags`

## Changes

- Added `version`, `commit`, and `date` build-time variables (main.go:19-24)
- Added `-version` flag to parseFlags (main.go:133, 145-148)
- Import `runtime` package to get Go version (main.go:10)
- Updated `.goreleaser.yaml` to embed version, commit, and date (lines 24-26)
- Version output format: `vip-elector version 0.1.2 (commit: b4fac10, date: 2025-10-08T05:56:12Z, go: go1.25.1)`

## Build Command

```bash
go build -ldflags="-X 'main.version=0.1.2' -X 'main.commit=$(git rev-parse --short HEAD)' -X 'main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)'" -o vip-elector
```

## Example Output

```bash
$ ./vip-elector -version
vip-elector version 0.1.2 (commit: b4fac10, date: 2025-10-08T05:56:12Z, go: go1.25.1)
```

## GoReleaser Integration

When releasing via GoReleaser, the build-time variables are automatically set:
- `version`: Set from git tag via `{{.Version}}`
- `commit`: Set from git commit via `{{.Commit}}`
- `date`: Set from build timestamp via `{{.Date}}`

## Test Plan

- [x] Build with ldflags (including date)
- [x] Verify version flag displays correct information
- [x] Verify commit hash is embedded correctly
- [x] Verify build date is embedded correctly
- [x] Verify Go version is displayed
- [x] Verify GoReleaser config includes all ldflags