### PR TITLE
Fix lock acquisition handling during transient Consul 500 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Network partition or node crash → Consul agent disconnects → Session invalid
 
 - `INFO: *** LOCK ACQUIRED ***` - This node became leader
 - `WARN: *** LOCK LOST ***` - Lost leadership, re-entering election
+- `WARN: Lock acquisition failed (error_type=consul_retryable)` - Transient Consul unavailability; vip-elector will retry
+- `ERROR: Lock acquisition failed (error_type=lock_conflict)` - Trigger key is incompatible with Lock API; process exits
 - `ERROR: Failed to create session` - Consul connectivity issues
 - `WARN: Health check verification failed` - Check ID not found
 
@@ -296,6 +298,39 @@ trigger-key pre-flight check failed: existing key at 'network/sakura-internal/vi
    consul acl token read -self
    ```
 
+### Consul 500 / i/o deadline reached during lock acquisition
+
+If vip-elector logs include `Lock acquisition failed` with `error_type=consul_retryable`,
+the failure is usually a transient Consul-side problem (for example: leader election, RPC timeout, or network jitter),
+not a confirmed lock contention with another node.
+
+Example log pattern:
+
+```json
+{"level":"WARN","msg":"Lock acquisition failed","error_type":"consul_retryable","error":"failed to read lock: Unexpected response code: 500 (... i/o deadline reached)"}
+```
+
+In this case vip-elector will:
+
+1. Destroy the current session
+2. Retry lock acquisition with backoff
+3. Continue leader election when Consul recovers
+
+What to check:
+
+1. Consul membership and raft leadership stability:
+   ```bash
+   consul members
+   consul operator raft list-peers
+   ```
+2. Consul agent/server logs around the same timestamp for timeout or election events.
+3. All components are watching the same trigger key (`<trigger-key>`).
+4. vip-manager status/logs, because L2 neighbor updates (including gratuitous ARP) are vip-manager's responsibility:
+   ```bash
+   sudo systemctl status vip-manager
+   sudo journalctl -u vip-manager -f
+   ```
+
 ### Frequent failovers (flapping)
 
 - Increase `--lock-delay` (e.g., `2s` or `5s`)
@@ -317,6 +352,9 @@ trigger-key pre-flight check failed: existing key at 'network/sakura-internal/vi
 3. Ensure vip-manager is monitoring the same trigger-key as vip-elector.
 
 4. Verify vip-manager configuration matches vip-elector's vip-manager.yml.
+
+5. Confirm vip-manager is configured correctly for post-switch L2 announcements.
+   vip-elector handles leader election and trigger-key updates only.
 
 ## Design Considerations
 

--- a/lock_behavior_test.go
+++ b/lock_behavior_test.go
@@ -68,7 +68,7 @@ func TestBuildLockOptions(t *testing.T) {
 	if opts.MonitorRetries != 3 {
 		t.Errorf("expected MonitorRetries=3, got %d", opts.MonitorRetries)
 	}
-	if opts.MonitorRetryTime != 2*time.Second {
-		t.Errorf("expected MonitorRetryTime=2s, got %v", opts.MonitorRetryTime)
+	if opts.MonitorRetryTime != 10*time.Second {
+		t.Errorf("expected MonitorRetryTime=10s, got %v", opts.MonitorRetryTime)
 	}
 }

--- a/lock_behavior_test.go
+++ b/lock_behavior_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func TestClassifyLockAcquireError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want lockAcquireErrorType
+	}{
+		{
+			name: "lock conflict",
+			err:  fmt.Errorf("wrapped: %w", api.ErrLockConflict),
+			want: lockAcquireErrorConflict,
+		},
+		{
+			name: "retryable consul 500",
+			err:  errors.New("failed to read lock: Unexpected response code: 500 (rpc error making call: i/o deadline reached)"),
+			want: lockAcquireErrorConsulRetryable,
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("unexpected failure"),
+			want: lockAcquireErrorUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyLockAcquireError(tt.err)
+			if got != tt.want {
+				t.Errorf("classifyLockAcquireError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildLockOptions(t *testing.T) {
+	opts := buildLockOptions("test/vip/lock", "node-a", "session-123")
+
+	if opts.Key != "test/vip/lock" {
+		t.Errorf("expected key=test/vip/lock, got %s", opts.Key)
+	}
+	if string(opts.Value) != "node-a" {
+		t.Errorf("expected value=node-a, got %s", string(opts.Value))
+	}
+	if opts.SessionOpts == nil {
+		t.Fatal("expected SessionOpts to be set")
+	}
+	if opts.SessionOpts.ID != "session-123" {
+		t.Errorf("expected session ID=session-123, got %s", opts.SessionOpts.ID)
+	}
+
+	if opts.MonitorRetries != defaultMonitorRetries {
+		t.Errorf("expected MonitorRetries=%d, got %d", defaultMonitorRetries, opts.MonitorRetries)
+	}
+	if opts.MonitorRetryTime != defaultMonitorRetryTime {
+		t.Errorf("expected MonitorRetryTime=%v, got %v", defaultMonitorRetryTime, opts.MonitorRetryTime)
+	}
+
+	if opts.MonitorRetries != 3 {
+		t.Errorf("expected MonitorRetries=3, got %d", opts.MonitorRetries)
+	}
+	if opts.MonitorRetryTime != 2*time.Second {
+		t.Errorf("expected MonitorRetryTime=2s, got %v", opts.MonitorRetryTime)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ const (
 	defaultLockDelay = "1s"
 	// Retry lock monitoring briefly on Consul 500/transient unavailability.
 	defaultMonitorRetries   = 3
-	defaultMonitorRetryTime = 2 * time.Second
+	defaultMonitorRetryTime = 10 * time.Second
 	// LockFlagValue is the magic flag Consul uses to identify lock keys
 	// See: https://github.com/hashicorp/consul/blob/main/api/lock.go
 	LockFlagValue uint64 = 0x2ddccbc058a50c18

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -26,6 +27,9 @@ var (
 const (
 	defaultTTL       = "10s"
 	defaultLockDelay = "1s"
+	// Retry lock monitoring briefly on Consul 500/transient unavailability.
+	defaultMonitorRetries   = 3
+	defaultMonitorRetryTime = 2 * time.Second
 	// LockFlagValue is the magic flag Consul uses to identify lock keys
 	// See: https://github.com/hashicorp/consul/blob/main/api/lock.go
 	LockFlagValue uint64 = 0x2ddccbc058a50c18
@@ -48,6 +52,14 @@ type Config struct {
 	ConsulToken          string
 	Hostname             string
 }
+
+type lockAcquireErrorType string
+
+const (
+	lockAcquireErrorConflict        lockAcquireErrorType = "lock_conflict"
+	lockAcquireErrorConsulRetryable lockAcquireErrorType = "consul_retryable"
+	lockAcquireErrorUnknown         lockAcquireErrorType = "lock_unknown"
+)
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -323,13 +335,7 @@ func runElectionLoop(ctx context.Context, client *api.Client, vipMgrConfig *VipM
 		backoff = time.Second
 
 		// Try to acquire lock
-		lock, err := client.LockOpts(&api.LockOptions{
-			Key:   vipMgrConfig.TriggerKey,
-			Value: []byte(hostname),
-			SessionOpts: &api.SessionEntry{
-				ID: sessionID,
-			},
-		})
+		lock, err := client.LockOpts(buildLockOptions(vipMgrConfig.TriggerKey, hostname, sessionID))
 		if err != nil {
 			slog.Error("Failed to create lock", "error", err)
 			// Destroy session
@@ -346,7 +352,17 @@ func runElectionLoop(ctx context.Context, client *api.Client, vipMgrConfig *VipM
 		// Acquire lock (blocks until acquired or context cancelled)
 		lockCh, err := lock.Lock(ctx.Done())
 		if err != nil {
-			slog.Info("Lock already held by another node, waiting for next election cycle", "error", err)
+			errorType := classifyLockAcquireError(err)
+			switch errorType {
+			case lockAcquireErrorConflict:
+				destroySession(client, sessionID)
+				return fmt.Errorf("lock acquisition failed (%s): %w", errorType, err)
+			case lockAcquireErrorConsulRetryable:
+				slog.Warn("Lock acquisition failed", "error_type", errorType, "error", err)
+			default:
+				slog.Error("Lock acquisition failed", "error_type", errorType, "error", err)
+			}
+
 			destroySession(client, sessionID)
 			select {
 			case <-time.After(backoff):
@@ -405,6 +421,30 @@ func runElectionLoop(ctx context.Context, client *api.Client, vipMgrConfig *VipM
 			return nil
 		}
 	}
+}
+
+func buildLockOptions(triggerKey, hostname, sessionID string) *api.LockOptions {
+	return &api.LockOptions{
+		Key:   triggerKey,
+		Value: []byte(hostname),
+		SessionOpts: &api.SessionEntry{
+			ID: sessionID,
+		},
+		// Retry monitor checks briefly so transient Consul 500 errors do not
+		// immediately trigger lock-loss handling.
+		MonitorRetries:   defaultMonitorRetries,
+		MonitorRetryTime: defaultMonitorRetryTime,
+	}
+}
+
+func classifyLockAcquireError(err error) lockAcquireErrorType {
+	if errors.Is(err, api.ErrLockConflict) {
+		return lockAcquireErrorConflict
+	}
+	if api.IsRetryableError(err) {
+		return lockAcquireErrorConsulRetryable
+	}
+	return lockAcquireErrorUnknown
 }
 
 func createSession(client *api.Client, config *Config, name string) (string, error) {


### PR DESCRIPTION
## Summary
- classify lock acquisition failures as `lock_conflict`, `consul_retryable`, or `lock_unknown`
- treat `lock_conflict` as fatal to avoid endless retries on incompatible lock keys
- set lock monitor retries to tolerate brief Consul 500/timeout periods
- update troubleshooting docs and clarify that L2 announcements (gratuitous ARP) are the responsibility of vip-manager

## Testing
- `go test -v -race ./... -tags='!e2e'`
- `make test-e2e`

Closes #4
